### PR TITLE
Add support for `pudb` detection

### DIFF
--- a/flake8_debugger.py
+++ b/flake8_debugger.py
@@ -11,6 +11,7 @@ DEBUGGER_ERROR_CODE = 'T002'
 
 debuggers = {
     'pdb': 'set_trace',
+    'pudb': 'set_trace',
     'ipdb': 'set_trace',
     'IPython.terminal.embed': 'InteractiveShellEmbed',
     'IPython.frontend.terminal.embed': 'InteractiveShellEmbed',


### PR DESCRIPTION
`pudb.set_trace()` is another common Python debugger.