### PR TITLE
Add a framework classifier

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -47,6 +47,7 @@ setup(
     classifiers=[
         'Development Status :: 4 - Beta',
         'Environment :: Console',
+        'Framework :: Flake8',
         'Intended Audience :: Developers',
         'License :: OSI Approved :: MIT License',
         'Operating System :: OS Independent',


### PR DESCRIPTION
Warehouse (pypi.org) allows search results to be filtered by trove classifiers.
One such classifier is `Framework`, which accepts `Flake8` as a value. Setting
the classifier should help people find flake8-comprehensions when searching for
flake8 plugins.