### PR TITLE
Detect __import__ debugger statements

### DIFF
--- a/flake8_debugger.py
+++ b/flake8_debugger.py
@@ -55,7 +55,7 @@ class DebuggerFinder(ast.NodeVisitor):
         debugger_method_names = chain(debuggers.values(), self.debuggers_traces_names.values())
         is_debugger_attribute = getattr(node.func, "attr", None) in list(debugger_method_names)
         if is_debugger_attribute:
-            caller = node.func.value.id
+            caller = getattr(node.func.value, "id", None)
             entry = self.debuggers_used.setdefault((node.lineno, node.col_offset), [])
             if caller in self.debuggers_names.values():
                 entry.append('{0} trace found: {1}.{2} used'.format(DEBUGGER_ERROR_CODE, caller, node.func.attr))

--- a/test_linter.py
+++ b/test_linter.py
@@ -78,6 +78,15 @@ class TestQA(object):
 
         assert result == expected_result
 
+    def test_catches_simple_debugger_when_called_off_global(self):
+        result = check_code_for_debugger_statements("__import__('ipdb').set_trace()")
+
+        expected_result = [
+            {'line': 1, 'message': 'T002 trace found: set_trace used', 'col': 0},
+        ]
+
+        assert result == expected_result
+
     @pytest.mark.skipif(True, reason="Not supported just yet")
     def test_catches_simple_debugger_when_called_off_var(self):
         result = check_code_for_debugger_statements('import ipdb\ntest = ipdb.set_trace\ntest()')


### PR DESCRIPTION
Flake8 Debugger stumbles upon following statement with an exception:

```__import__('ipdb').set_trace()```

I first encountered this issue with an update of popular [vim-snippets](https://github.com/honza/vim-snippets/commit/755c95fa3985d97a26a94daf94d4ca11aa5f7381). Once this statement is in the code whole flake8 process won't run as it stops with an exception.

This PR fixes the issue that no exception is raised and the debugger statement is correctly detected.