### PR TITLE
Handle builtin `breakpoint` debugger tracing call

### DIFF
--- a/flake8_debugger.py
+++ b/flake8_debugger.py
@@ -1,5 +1,6 @@
 """Extension for flake8 that finds usage of the debugger."""
 import ast
+import sys
 from itertools import chain
 
 import pycodestyle
@@ -17,6 +18,9 @@ debuggers = {
     'IPython.frontend.terminal.embed': ['InteractiveShellEmbed'],
 }
 
+if sys.version_info >= (3, 7):
+    debuggers['builtins'] = ['breakpoint']
+
 
 class DebuggerFinder(ast.NodeVisitor):
     def __init__(self, *args, **kwargs):
@@ -30,6 +34,10 @@ class DebuggerFinder(ast.NodeVisitor):
         self.debuggers_imported = {}
 
     def visit_Call(self, node):
+        if sys.version_info >= (3, 7) and getattr(node.func, 'id', None) == 'breakpoint':
+            entry = self.debuggers_used.setdefault((node.lineno, node.col_offset), [])
+            entry.append('{0} trace found: breakpoint used'.format(DEBUGGER_ERROR_CODE))
+
         debugger_method_names = list(chain(self.debuggers_traces_names.values(), *debuggers.values()))
         is_debugger_function = getattr(node.func, "id", None) in debugger_method_names
         if is_debugger_function:

--- a/test_linter.py
+++ b/test_linter.py
@@ -98,6 +98,48 @@ class TestQA(object):
         assert result == expected_result
 
 
+class TestBreakpoint(object):
+
+    @pytest.mark.skipif(sys.version_info < (3, 7), reason='breakpoint builtin introduced in 3.7')
+    def test_catches_breakpoint_call_for_python_3_7_and_above(self):
+        result = check_code_for_debugger_statements('breakpoint()')
+
+        expected_result = [
+            {'line': 1, 'message': 'T100 trace found: breakpoint used', 'col': 0}
+        ]
+
+        assert result == expected_result
+
+    @pytest.mark.skipif(sys.version_info < (3, 7), reason='breakpoint builtin introduced in 3.7')
+    def test_catches_breakpoint_import(self):
+        result = check_code_for_debugger_statements('from builtins import breakpoint')
+
+        expected_result = [
+            {'line': 1, 'message': 'T100 import for breakpoint found', 'col': 0},
+        ]
+
+        assert result == expected_result
+
+    @pytest.mark.skipif(sys.version_info < (3, 7), reason='breakpoint builtin introduced in 3.7')
+    def test_catches_breakpoint_imported_as_other_name(self):
+        result = check_code_for_debugger_statements('from builtins import breakpoint as b\nb()')
+
+        expected_result = [
+            {'line': 2, 'message': 'T100 trace found: breakpoint used as b', 'col': 0},
+            {'line': 1, 'message': 'T100 import for breakpoint found as b', 'col': 0},
+        ]
+
+        assert result == expected_result
+
+    @pytest.mark.skipif(sys.version_info >= (3, 7), reason='breakpoint builtin introduced in 3.7')
+    def test_allows_breakpoint_call_for_python_below_3_7(self):
+        result = check_code_for_debugger_statements('breakpoint()')
+
+        expected_result = []
+
+        assert result == expected_result
+
+
 class TestNoQA(object):
 
     @pytest.mark.skipif(sys.version_info < (2, 7), reason="Python 2.6 does not support noqa")


### PR DESCRIPTION
The `breakpoint` builtin function has been introduced in Python 3.7: https://docs.python.org/3/whatsnew/3.7.html#pep-553-built-in-breakpoint

`breakpoint()` calls and import of `breakpoint` from `builtins` will trigger warnings when running under Python 3.7 or above.

However, this also include calls to user-defined functions named "breakpoint" that shadow the builtin. It could be nice if the following snippet did not trigger a warning, but with the current implementation, it does:

```
def breakpoint():
    pass
breakpoint()
```

That said, this is also the case for unorthodox redefinitions of `pdb` or `set_trace`. While it could be argued that shadowing `breakpoint` is more likely than shadowing `pdb`, I still think that this change is worth to be released as is, since it should cover the vast majority of "regular" uses of `breakpoint`.

Closes #12
