### PR TITLE
Fix formatting.

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,8 +11,8 @@ Installation
 
 You can install or upgrade ``flake8-debugger`` with these commands::
 
-  $ pip install flake8-debugger
-  $ pip install --upgrade flake8-debugger
+    $ pip install flake8-debugger
+    $ pip install --upgrade flake8-debugger
 
 
 Plugin for Flake8


### PR DESCRIPTION
This didn't turn into a code block when rendered because it only used two spaces.